### PR TITLE
Added per-triangle attribute to allow re-mapping of vertex attribute …

### DIFF
--- a/CorkLib/FileFormats/off.cpp
+++ b/CorkLib/FileFormats/off.cpp
@@ -138,7 +138,7 @@ namespace Cork
 			// face data
 
 			{
-				TriangleMesh::TriangleByIndices		newTriangle( 0, 0, 0 );
+				TriangleMesh::TriangleByIndices		newTriangle( 0, 0, 0, -1 );
 				unsigned int						polySize;
 				TriangleMeshBuilderResultCodes		resultCode;
 

--- a/CorkLib/Math/Primitives.h
+++ b/CorkLib/Math/Primitives.h
@@ -169,15 +169,18 @@ namespace Cork
 			TriangleByIndicesBase()
 				: m_a( -1 ),
 				  m_b( -1 ),
-				  m_c( -1 )
+				  m_c( -1 ),
+				  m_id( -1 )
 			{}
 
 			TriangleByIndicesBase( VertexIndex		a,
 								   VertexIndex		b,
-								   VertexIndex		c )
+								   VertexIndex		c,
+								   VertexIndex		id=-1)
 				: m_a( a ),
 				  m_b( b ),
-				  m_c( c )
+				  m_c( c ),
+				  m_id( id )
 			{}
 
 	
@@ -226,6 +229,15 @@ namespace Cork
 				return( m_c );
 			}
 
+			const VertexIndex				id() const
+			{
+				return m_id;
+			}
+
+			VertexIndex&					id()
+			{
+				return m_id;
+			}
 
 		protected :
 
@@ -236,9 +248,10 @@ namespace Cork
 					VertexIndex			m_a;
 					VertexIndex			m_b;
 					VertexIndex			m_c;
+					VertexIndex			m_id;
 				};
 
-				std::array<VertexIndex,3>		m_indices;
+				std::array<VertexIndex,4>		m_indices;
 			};
 		};
 

--- a/CorkLib/Mesh/Intersection.cpp
+++ b/CorkLib/Mesh/Intersection.cpp
@@ -1214,6 +1214,7 @@ namespace Cork
 								 const TopoTri&		parent )
 			{
 				TopoCache::ownerMesh().triangles()[piece.ref()].boolAlgData() = ownerMesh().triangles()[parent.ref()].boolAlgData();
+				TopoCache::ownerMesh().triangles()[piece.ref()].id() = ownerMesh().triangles()[parent.ref()].id();
 			}
 
 

--- a/CorkLib/Mesh/Mesh.cpp
+++ b/CorkLib/Mesh/Mesh.cpp
@@ -496,7 +496,7 @@ namespace Cork
 
 			if( !findResult.Succeeded() )
 			{
-				//	If we failed here - not mush to do but return a failed result
+				//	If we failed here - not much to do but return a failed result
 
 				return( SetupBooleanProblemResult::Failure( SetupBooleanProblemResultCodes::FIND_INTERSECTIONS_FAILED, "FindIntersections failed.", findResult ));
 			}
@@ -1160,9 +1160,9 @@ namespace Cork
 			triangleMeshBuilder->AddVertex(Cork::TriangleMesh::Vertex((NUMERIC_PRECISION)currentVertex.x(), (NUMERIC_PRECISION)currentVertex.y(), (NUMERIC_PRECISION)currentVertex.z()));
 		}
 
-		for_raw_tris( [&]( IndexType a, IndexType b, IndexType c )
+		for_raw_tris( [&]( IndexType a, IndexType b, IndexType c, IndexType id )
 		{
-			triangleMeshBuilder->AddTriangle( TriangleMesh::TriangleByIndices( a, b, c ) );
+			triangleMeshBuilder->AddTriangle( TriangleMesh::TriangleByIndices( a, b, c, id ) );
 		} );
 
 		return(triangleMeshBuilder->Mesh());

--- a/CorkLib/Mesh/MeshBase.h
+++ b/CorkLib/Mesh/MeshBase.h
@@ -278,19 +278,19 @@ namespace Cork
 			return( Quantization::Quantizer(maxMag, sqrt( minEdgeLengthSquared )));
 		}
 
-		void for_raw_tris( std::function<void( IndexType, IndexType, IndexType )> func )
+		void for_raw_tris( std::function<void( IndexType, IndexType, IndexType, IndexType )> func )
 		{
 			for ( auto& tri : m_tris )
 			{
-				func( tri.a(), tri.b(), tri.c() );
+				func( tri.a(), tri.b(), tri.c(), tri.id() );
 			}
 		}
 
-		void for_raw_tris( std::function<void( IndexType, IndexType, IndexType )> func ) const
+		void for_raw_tris( std::function<void( IndexType, IndexType, IndexType, IndexType )> func ) const
 		{
 			for ( auto& tri : m_tris )
 			{
-				func( tri.a(), tri.b(), tri.c() );
+				func( tri.a(), tri.b(), tri.c(), tri.id() );
 			}
 		}
 

--- a/CorkLib/TriangleMesh.cpp
+++ b/CorkLib/TriangleMesh.cpp
@@ -240,7 +240,8 @@ namespace Cork
 
 			TriangleMesh::TriangleByIndices		remappedTriangle( m_vertexIndexRemapper[triangleToAdd[0]],
 																  m_vertexIndexRemapper[triangleToAdd[1]],
-																  m_vertexIndexRemapper[triangleToAdd[2]] );
+																  m_vertexIndexRemapper[triangleToAdd[2]],
+																  triangleToAdd[3]);
 
 			//	Add the triangle to the vector
 

--- a/CorkLib/TriangleMesh.h
+++ b/CorkLib/TriangleMesh.h
@@ -116,7 +116,7 @@ namespace Cork
 	class IncrementalVertexIndexTriangleMeshBuilder
 	{
 	public:
-
+		CORKLIB_API
 		static std::unique_ptr<IncrementalVertexIndexTriangleMeshBuilder>		GetBuilder( size_t		numVertices = 0,
 																							size_t		numTriangles = 0 );
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Cork
+Cork Computational Library forked from source code by Gilbert Bernstein.
+
+This adds an integer id to each triangle that is preserved through the CSG operation, and given to any triangle subdivided from an input triangle.
+
+If you just want to preseve the source mesh, put a mesh ID in there. If you need to preserve the material (for example for physics simulation) you can put a material ID.
+To transfer per-vertex attribute (normal, vertex colour, uv, etc.) you can put a unique triangle ID in there to map back to the source mesh and triangle. You can then interpolate the vertex parameters for each new vertex.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cork
 Cork Computational Library forked from source code by Gilbert Bernstein.
 
-This adds an integer id to each triangle that is preserved through the CSG operation, and given to any triangle subdivided from an input triangle.
+This branch adds an integer id to each triangle that is preserved through the CSG operation, and given to any triangle subdivided from an input triangle.
 
 If you just want to preseve the source mesh, put a mesh ID in there. If you need to preserve the material (for example for physics simulation) you can put a material ID.
 To transfer per-vertex attribute (normal, vertex colour, uv, etc.) you can put a unique triangle ID in there to map back to the source mesh and triangle. You can then interpolate the vertex parameters for each new vertex.


### PR DESCRIPTION
…after the CSG operation

This adds an additional "IndexType" parameter to each triangle, to help transfer material information from the source meshes to the target meshes. This value is inherited by each new triangle created from a source triangle.

In the easiest case this is just a simple material or mesh index, for example for physical properties. This can be a source triangle id as well, which can then be mapped back to the individual source mesh and triangle. The source triangle can then be used to interpolate per-vertex attribute for the vertices of the new triangle.
